### PR TITLE
Fix non-AHP allocation matching_skills output

### DIFF
--- a/mba_project/mba_project/matching.py
+++ b/mba_project/mba_project/matching.py
@@ -162,7 +162,7 @@ def allocate(df_jobs: pd.DataFrame,
                         'talent_english_level': talent.english_level,
                         'talent_experience_years': talent.experience_years,
                         'number_of_matched_skills': number_of_matched_skills,
-                        'matching_skills': matching_skills,
+                        'matching_skills': ', '.join(matching_skills),
                         'has_main_skill': has_main_skill
                     })
 


### PR DESCRIPTION
## Summary
- ensure matching skills in non-AHP allocation are stored as a comma-separated string

## Testing
- `python -m py_compile mba_project/mba_project/matching.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684322aed4f8832f8729c5dc3fb43dd0